### PR TITLE
Download cloud_sql_proxy binary, cached for future builds

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+BUILD_DIR=$1
+CACHE_DIR=$2
+ENV_DIR=$3
+
+CLOUD_SQL_PROXY_VERSION="v2.18.0"
+CLOUD_SQL_PROXY_URL="https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/${CLOUD_SQL_PROXY_VERSION}/cloud-sql-proxy.linux.amd64"
+CACHED_BINARY="$CACHE_DIR/cloud-sql-proxy-${CLOUD_SQL_PROXY_VERSION}"
+
+echo "-----> Installing Cloud SQL Proxy ${CLOUD_SQL_PROXY_VERSION}"
+
+# Create directories
+mkdir -p "$BUILD_DIR/bin"
+mkdir -p "$CACHE_DIR"
+
+# Check if binary exists in cache
+if [[ -f "$CACHED_BINARY" ]]; then
+    echo "       Using cached binary"
+    cp "$CACHED_BINARY" "$BUILD_DIR/bin/cloud-sql-proxy"
+else
+    echo "       Downloading from ${CLOUD_SQL_PROXY_URL}"
+    curl -L -o "$BUILD_DIR/bin/cloud-sql-proxy" "$CLOUD_SQL_PROXY_URL"
+
+    # Cache the binary for future builds
+    echo "       Caching binary for future builds"
+    cp "$BUILD_DIR/bin/cloud-sql-proxy" "$CACHED_BINARY"
+fi
+
+# Make it executable
+chmod +x "$BUILD_DIR/bin/cloud-sql-proxy"
+
+echo "       Cloud SQL Proxy installed to bin/cloud-sql-proxy"
+
+exit 0

--- a/bin/detect
+++ b/bin/detect
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Cloud SQL Proxy"
+exit 0

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0


### PR DESCRIPTION
- Creating a buildpack to install the latest cloud_sql_proxy (existing buildpacks lack updates)
- Once cloud sql IAM permissions are added to arcade's GCP service account, we can connect the proxy to cloud sql at startup by invoking in Procfile and passing in the existing GCP creds file